### PR TITLE
[Change] Support CAA records in dns query parameters

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -7,7 +7,7 @@ build_ignore:
   - .yamllint
 description: A collection of cloudflare roles
 dependencies:
-  community.general: '*'
+  community.general: '>=8.0.0'
 documentation: https://github.com/linuxhq/ansible-collection-cloudflare/blob/main/README.md
 homepage: https://www.linuxhq.org
 issues: https://github.com/linuxhq/ansible-collection-cloudflare/issues

--- a/roles/dns/tasks/main.yml
+++ b/roles/dns/tasks/main.yml
@@ -6,6 +6,7 @@
     algorithm: "{{ _dns.1.algorithm | default(omit) }}"
     api_token: "{{ cf_auth_token }}"
     cert_usage: "{{ _dns.1.cert_usage | default(omit) }}"
+    flag: "{{ _dns.1.flag | default(omit) }}"
     hash_type: "{{ _dns.1.hash_type | default(omit) }}"
     key_tag: "{{ _dns.1.key_tag | default(omit) }}"
     port: "{{ _dns.1.port | default(omit) }}"
@@ -17,6 +18,7 @@
     service: "{{ _dns.1.service | default(omit) }}"
     solo: "{{ _dns.1.solo | default(omit) }}"
     state: present
+    tag: "{{ _dns.1.tag | default(omit) }}"
     timeout: "{{ _dns.0.timeout | default(30) }}"
     ttl: "{{ _dns.1.ttl | default(1) }}"
     type: "{{ _dns.1.type | upper }}"


### PR DESCRIPTION
CAA DNS records require also flags and tag params in the CF API:
https://developers.cloudflare.com/api/operations/dns-records-for-a-zone-create-dns-record

at community.general/.../cloudflare_dns.py this is translated from `{ 'flag': value, 'tag': tag }`, so the missing params are flag and tag.

this patch adds both.

```
TASK [linuxhq.cloudflare.dns : Ensure cloudflare dns records are present] **************************************************************************************************************************************************************************************************************************************************
changed: [localhost] => (item=CAA:@.test.com)
```
