### PR TITLE
Restore directory-level agent symlinks

### DIFF
--- a/.claude/rules
+++ b/.claude/rules
@@ -1,0 +1,1 @@
+../.agents/rules

--- a/.claude/rules/helpers.md
+++ b/.claude/rules/helpers.md
@@ -1,1 +1,0 @@
-../../.agents/rules/helpers.md

--- a/.claude/rules/module-authoring.md
+++ b/.claude/rules/module-authoring.md
@@ -1,1 +1,0 @@
-../../.agents/rules/module-authoring.md

--- a/.claude/rules/module-docs.md
+++ b/.claude/rules/module-docs.md
@@ -1,1 +1,0 @@
-../../.agents/rules/module-docs.md

--- a/.claude/rules/role-authoring.md
+++ b/.claude/rules/role-authoring.md
@@ -1,1 +1,0 @@
-../../.agents/rules/role-authoring.md

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/.claude/skills/ansible-lint/SKILL.md
+++ b/.claude/skills/ansible-lint/SKILL.md
@@ -1,1 +1,0 @@
-../../../.agents/skills/ansible-lint/SKILL.md

--- a/.claude/skills/ansible-test/SKILL.md
+++ b/.claude/skills/ansible-test/SKILL.md
@@ -1,1 +1,0 @@
-../../../.agents/skills/ansible-test/SKILL.md

--- a/.claude/skills/black/SKILL.md
+++ b/.claude/skills/black/SKILL.md
@@ -1,1 +1,0 @@
-../../../.agents/skills/black/SKILL.md

--- a/.claude/skills/changelog/SKILL.md
+++ b/.claude/skills/changelog/SKILL.md
@@ -1,1 +1,0 @@
-../../../.agents/skills/changelog/SKILL.md

--- a/.claude/skills/collection-build/SKILL.md
+++ b/.claude/skills/collection-build/SKILL.md
@@ -1,1 +1,0 @@
-../../../.agents/skills/collection-build/SKILL.md

--- a/.claude/skills/molecule/SKILL.md
+++ b/.claude/skills/molecule/SKILL.md
@@ -1,1 +1,0 @@
-../../../.agents/skills/molecule/SKILL.md

--- a/.claude/skills/pyenv/SKILL.md
+++ b/.claude/skills/pyenv/SKILL.md
@@ -1,1 +1,0 @@
-../../../.agents/skills/pyenv/SKILL.md

--- a/.claude/skills/ruff/SKILL.md
+++ b/.claude/skills/ruff/SKILL.md
@@ -1,1 +1,0 @@
-../../../.agents/skills/ruff/SKILL.md

--- a/.claude/skills/virtualenv/SKILL.md
+++ b/.claude/skills/virtualenv/SKILL.md
@@ -1,1 +1,0 @@
-../../../.agents/skills/virtualenv/SKILL.md

--- a/.claude/skills/yamllint/SKILL.md
+++ b/.claude/skills/yamllint/SKILL.md
@@ -1,1 +1,0 @@
-../../../.agents/skills/yamllint/SKILL.md

--- a/.codex/rules
+++ b/.codex/rules
@@ -1,0 +1,1 @@
+../.agents/rules

--- a/.codex/rules/helpers.md
+++ b/.codex/rules/helpers.md
@@ -1,1 +1,0 @@
-../../.agents/rules/helpers.md

--- a/.codex/rules/module-authoring.md
+++ b/.codex/rules/module-authoring.md
@@ -1,1 +1,0 @@
-../../.agents/rules/module-authoring.md

--- a/.codex/rules/module-docs.md
+++ b/.codex/rules/module-docs.md
@@ -1,1 +1,0 @@
-../../.agents/rules/module-docs.md

--- a/.codex/rules/role-authoring.md
+++ b/.codex/rules/role-authoring.md
@@ -1,1 +1,0 @@
-../../.agents/rules/role-authoring.md

--- a/.codex/skills
+++ b/.codex/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/.codex/skills/ansible-lint/SKILL.md
+++ b/.codex/skills/ansible-lint/SKILL.md
@@ -1,1 +1,0 @@
-../../../.agents/skills/ansible-lint/SKILL.md

--- a/.codex/skills/ansible-test/SKILL.md
+++ b/.codex/skills/ansible-test/SKILL.md
@@ -1,1 +1,0 @@
-../../../.agents/skills/ansible-test/SKILL.md

--- a/.codex/skills/black/SKILL.md
+++ b/.codex/skills/black/SKILL.md
@@ -1,1 +1,0 @@
-../../../.agents/skills/black/SKILL.md

--- a/.codex/skills/changelog/SKILL.md
+++ b/.codex/skills/changelog/SKILL.md
@@ -1,1 +1,0 @@
-../../../.agents/skills/changelog/SKILL.md

--- a/.codex/skills/collection-build/SKILL.md
+++ b/.codex/skills/collection-build/SKILL.md
@@ -1,1 +1,0 @@
-../../../.agents/skills/collection-build/SKILL.md

--- a/.codex/skills/molecule/SKILL.md
+++ b/.codex/skills/molecule/SKILL.md
@@ -1,1 +1,0 @@
-../../../.agents/skills/molecule/SKILL.md

--- a/.codex/skills/pyenv/SKILL.md
+++ b/.codex/skills/pyenv/SKILL.md
@@ -1,1 +1,0 @@
-../../../.agents/skills/pyenv/SKILL.md

--- a/.codex/skills/ruff/SKILL.md
+++ b/.codex/skills/ruff/SKILL.md
@@ -1,1 +1,0 @@
-../../../.agents/skills/ruff/SKILL.md

--- a/.codex/skills/virtualenv/SKILL.md
+++ b/.codex/skills/virtualenv/SKILL.md
@@ -1,1 +1,0 @@
-../../../.agents/skills/virtualenv/SKILL.md

--- a/.codex/skills/yamllint/SKILL.md
+++ b/.codex/skills/yamllint/SKILL.md
@@ -1,1 +1,0 @@
-../../../.agents/skills/yamllint/SKILL.md

--- a/tests/sanity/ignore-2.18.txt
+++ b/tests/sanity/ignore-2.18.txt
@@ -1,0 +1,4 @@
+.claude/rules/ symlinks
+.claude/skills/ symlinks
+.codex/rules/ symlinks
+.codex/skills/ symlinks

--- a/tests/sanity/ignore-2.21.txt
+++ b/tests/sanity/ignore-2.21.txt
@@ -1,0 +1,4 @@
+.claude/rules/ symlinks
+.claude/skills/ symlinks
+.codex/rules/ symlinks
+.codex/skills/ symlinks


### PR DESCRIPTION
## Summary
- Restore .claude and .codex rules/skills as directory symlinks into .agents (per-file symlinks reverted)
- Add tests/sanity ignore entries for the ansible-test symlinks check on both CI matrices (core 2.18 and 2.21), which otherwise forbids directory symlinks

## Testing
- Full ansible-test sanity suite passes locally on core 2.21, including the symlinks test with the ignore entries