### PR TITLE
Remove unused AWS dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,6 @@
 ansible>14,<15
 ansible-lint==25.9.1
 antsibull-changelog==0.34.0
-awscli==1.45.50
-boto3==1.36.10
-botocore==1.43.50
 cloudflare>=4.3.1,<5
 docker==7.2.0
 jmespath==1.0.1


### PR DESCRIPTION
## Summary
- Drop awscli, boto3, and botocore from requirements.txt — nothing in this Cloudflare collection uses them, and the Dependabot botocore bump had left an incompatible boto3 pin behind
- jmespath is kept: the info roles use json_query 15 times