### PR TITLE
Release v2.1.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 __pycache__/
 *.py[co]
 venv
+changelogs/.plugin-cache.yaml

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,26 @@ linuxhq.cloudflare Release Notes
 
 .. contents:: Topics
 
+v2.1.2
+======
+
+Release Summary
+---------------
+
+Maintenance release. Listing and name lookups follow API pagination everywhere, and the collection now requires ansible-core 2.18 and community.general 12.
+
+Breaking Changes / Porting Guide
+--------------------------------
+
+- Raised the minimum supported ansible-core version to 2.18.0 and the community.general dependency to ``>=12.0.0,<14.0.0``.
+
+Bugfixes
+--------
+
+- access_groups - paginate the name lookup so groups beyond the first page of name-filter matches are found instead of recreated.
+- access_service_tokens - paginate the name lookup so tokens beyond the first page of name-filter matches are found instead of recreated.
+- pages_projects_info - paginate the Pages projects listing so accounts with more projects than one API page return complete results.
+
 v2.1.1
 ======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -1,145 +1,13 @@
 ---
 ancestor: null
 releases:
-  2.1.1:
-    release_date: '2026-07-14'
+  1.2.0:
     changes:
-      release_summary: >-
-        Bugfix release that restores support for all Cloudflare Access
-        application types.
-      bugfixes:
-        - access_apps - the ``type`` option is no longer restricted to a subset of
-          application types; ``warp`` and other valid Cloudflare Access application
-          types are accepted again.
-  2.1.0:
-    release_date: '2026-07-14'
-    changes:
-      release_summary: >-
-        Hardening release. Modules follow API pagination, converge more reliably,
-        and handle Cloudflare errors and long-running operations predictably.
-        Review the breaking changes before upgrading.
-      minor_changes:
-        - all - resource lookups use server-side filters and follow API pagination where supported.
-        - cfd_tunnel, pages_projects, warp_connector - added ``rotate_secrets`` to apply write-only secrets to existing resources.
-        - galaxy.yml - constrained ``community.general`` to ``<11.0.0`` for ansible-core 2.15 compatibility.
-        - rules_lists - added ``operation_timeout`` to bound bulk item operations.
-      breaking_changes:
-        - access_apps - the ``type`` option is restricted to ``self_hosted``, ``ssh``, and ``vnc``.
-        - access_policies - removed the ``precedence`` option; the account-level Access policy API does not accept it.
-        - zones - removed the ``internal`` zone type.
-      bugfixes:
-        - all - numerous idempotency and convergence fixes, including complete pagination in
-          lookups and info modules, write-only secret comparison, preserved omitted fields on
-          update, and stricter bulk-operation handling.
-      security_fixes:
-        - access_apps, access_apps_info, access_identity_providers_info - secret fields in SCIM and identity provider responses are redacted.
-        - examples, cfd_tunnel - removed a hardcoded tunnel secret; provide ``CLOUDFLARE_TUNNEL_SECRET`` via the environment instead.
-        - pages_projects - ``deployment_configs`` is not logged; it can contain ``secret_text`` values.
-  2.0.9:
-    release_date: '2026-06-03'
-    changes:
-      release_summary: >-
-        Maintenance release that refreshes the plugin development guidelines and
-        refactors all modules to follow them. No functional changes.
-      minor_changes:
-        - all - refactored every module to follow the updated development guidelines.
-        - all - updated the plugin development guidelines.
-  2.0.8:
-    release_date: '2026-05-28'
-    changes:
-      release_summary: >-
-        Adds agent workflow support and applies general module cleanup.
-      minor_changes:
-        - all - added support for agent workflows.
-        - all - general module cleanup.
-  2.0.7:
-    release_date: '2026-05-11'
-    changes:
-      release_summary: >-
-        Fixes access service token lookups by no longer passing the unsupported
-        ``per_page`` parameter.
-      minor_changes:
-        - access_service_tokens - no longer passes the unsupported ``per_page`` parameter when looking up service tokens.
-  2.0.6:
-    release_date: '2026-05-11'
-    changes:
-      release_summary: >-
-        Replaces the ``uri``-based API wrappers with custom Ansible modules built on
-        the official ``cloudflare`` Python SDK, and adds async support to the
-        applicable roles. Review the breaking changes before upgrading.
-      minor_changes:
-        - all - added async support to the applicable roles.
-        - all - migrated every role from ``uri`` wrappers to custom Ansible modules.
-      breaking_changes:
-        - devices_policy - defaults have been broken out into individual role variables.
-        - pages_projects - DNS record management has been removed; use the ``dns`` role instead.
-  2.0.5:
-    release_date: '2026-02-23'
-    changes:
-      release_summary: >-
-        Adds support for Cloudflare-managed tunnels, including new roles for managing
-        and inspecting tunnel configurations.
-      minor_changes:
-        - all - removed ``box_architecture`` from the molecule configuration.
-        - all - removed tags from the molecule verify plays.
-        - cfd_tunnel - added support for Cloudflare-managed tunnels.
-        - cfd_tunnel_configurations - new role for managing tunnel configurations.
-        - cfd_tunnel_configurations_info - new role for gathering tunnel configurations.
-      breaking_changes:
-        - cfd_tunnel - ``config_src`` must now be defined for each tunnel in inventory.
-  2.0.4:
-    release_date: '2026-01-16'
-    changes:
-      release_summary: >-
-        Introduces the ``access_identity_providers_info`` role.
-      minor_changes:
-        - access_identity_providers_info - new role for gathering Access identity providers.
-        - access_policies - added a meta dependency on ``access_identity_providers_info``.
-  2.0.3:
-    release_date: '2025-11-26'
-    changes:
-      release_summary: >-
-        Introduces the ``dnssec`` and ``dnssec_info`` roles.
-      minor_changes:
-        - dnssec - new role for managing zone DNSSEC settings.
-        - dnssec_info - new role for gathering zone DNSSEC settings.
-  2.0.2:
-    release_date: '2025-11-22'
-    changes:
-      release_summary: >-
-        Introduces eight new roles for Cloudflare WARP and Zero Trust device
-        management.
-      minor_changes:
-        - devices_policy - new role for managing device policies.
-        - devices_policy_info - new role for gathering device policies.
-        - devices_settings - new role for managing device settings.
-        - devices_settings_info - new role for gathering device settings.
-        - warp_connector - new role for managing WARP connectors.
-        - warp_connector_info - new role for gathering WARP connectors.
-        - zerotrust_connectivity_settings - new role for managing Zero Trust connectivity settings.
-        - zerotrust_connectivity_settings_info - new role for gathering Zero Trust connectivity settings.
-  2.0.1:
-    release_date: '2025-11-08'
-    changes:
-      release_summary: >-
-        Adds support for the ``destinations`` option in the ``access_apps`` role,
-        allowing multiple domains to be associated with a single application.
-      minor_changes:
-        - access_apps - added support for the ``destinations`` option.
+      release_summary: Final 1.x release. All 1.x releases are deprecated and no longer receive updates; please
+        upgrade to 2.0.0 or later.
+    release_date: '2024-03-31'
   2.0.0:
-    release_date: '2025-11-06'
     changes:
-      release_summary: >-
-        Restructures the entire collection. Most roles have been renamed and several
-        deprecated roles were removed, so all inventory and playbooks must be updated
-        when upgrading from 1.x. See the provided examples.
-      minor_changes:
-        - all - added ``check_mode`` support to avoid failures.
-        - all - added ``state`` support to all applicable roles.
-        - all - added example inventory and playbooks.
-        - all - added molecule tests to every role.
-        - all - the ansible-lint configuration no longer carries any exclusions.
-        - purge_cache - new role for purging the Cloudflare cache.
       breaking_changes:
         - access_apps - renamed from ``access_app``.
         - access_apps_info - renamed from ``access_app_info``.
@@ -166,10 +34,145 @@ releases:
         - ssl - removed.
         - zones - renamed from ``zone``.
         - zones_info - renamed from ``zone_info``.
-  1.2.0:
-    release_date: '2024-03-31'
+      minor_changes:
+        - all - added ``check_mode`` support to avoid failures.
+        - all - added ``state`` support to all applicable roles.
+        - all - added example inventory and playbooks.
+        - all - added molecule tests to every role.
+        - all - the ansible-lint configuration no longer carries any exclusions.
+        - purge_cache - new role for purging the Cloudflare cache.
+      release_summary: Restructures the entire collection. Most roles have been renamed and several deprecated roles
+        were removed, so all inventory and playbooks must be updated when upgrading from 1.x. See the provided examples.
+    release_date: '2025-11-06'
+  2.0.1:
     changes:
-      release_summary: >-
-        Final 1.x release. All 1.x releases are deprecated and no longer receive
-        updates; please upgrade to 2.0.0 or later.
+      minor_changes:
+        - access_apps - added support for the ``destinations`` option.
+      release_summary: Adds support for the ``destinations`` option in the ``access_apps`` role, allowing multiple
+        domains to be associated with a single application.
+    release_date: '2025-11-08'
+  2.0.2:
+    changes:
+      minor_changes:
+        - devices_policy - new role for managing device policies.
+        - devices_policy_info - new role for gathering device policies.
+        - devices_settings - new role for managing device settings.
+        - devices_settings_info - new role for gathering device settings.
+        - warp_connector - new role for managing WARP connectors.
+        - warp_connector_info - new role for gathering WARP connectors.
+        - zerotrust_connectivity_settings - new role for managing Zero Trust connectivity settings.
+        - zerotrust_connectivity_settings_info - new role for gathering Zero Trust connectivity settings.
+      release_summary: Introduces eight new roles for Cloudflare WARP and Zero Trust device management.
+    release_date: '2025-11-22'
+  2.0.3:
+    changes:
+      minor_changes:
+        - dnssec - new role for managing zone DNSSEC settings.
+        - dnssec_info - new role for gathering zone DNSSEC settings.
+      release_summary: Introduces the ``dnssec`` and ``dnssec_info`` roles.
+    release_date: '2025-11-26'
+  2.0.4:
+    changes:
+      minor_changes:
+        - access_identity_providers_info - new role for gathering Access identity providers.
+        - access_policies - added a meta dependency on ``access_identity_providers_info``.
+      release_summary: Introduces the ``access_identity_providers_info`` role.
+    release_date: '2026-01-16'
+  2.0.5:
+    changes:
+      breaking_changes:
+        - cfd_tunnel - ``config_src`` must now be defined for each tunnel in inventory.
+      minor_changes:
+        - all - removed ``box_architecture`` from the molecule configuration.
+        - all - removed tags from the molecule verify plays.
+        - cfd_tunnel - added support for Cloudflare-managed tunnels.
+        - cfd_tunnel_configurations - new role for managing tunnel configurations.
+        - cfd_tunnel_configurations_info - new role for gathering tunnel configurations.
+      release_summary: Adds support for Cloudflare-managed tunnels, including new roles for managing and inspecting
+        tunnel configurations.
+    release_date: '2026-02-23'
+  2.0.6:
+    changes:
+      breaking_changes:
+        - devices_policy - defaults have been broken out into individual role variables.
+        - pages_projects - DNS record management has been removed; use the ``dns`` role instead.
+      minor_changes:
+        - all - added async support to the applicable roles.
+        - all - migrated every role from ``uri`` wrappers to custom Ansible modules.
+      release_summary: Replaces the ``uri``-based API wrappers with custom Ansible modules built on the official
+        ``cloudflare`` Python SDK, and adds async support to the applicable roles. Review the breaking changes before
+        upgrading.
+    release_date: '2026-05-11'
+  2.0.7:
+    changes:
+      minor_changes:
+        - access_service_tokens - no longer passes the unsupported ``per_page`` parameter when looking up service
+          tokens.
+      release_summary: Fixes access service token lookups by no longer passing the unsupported ``per_page`` parameter.
+    release_date: '2026-05-11'
+  2.0.8:
+    changes:
+      minor_changes:
+        - all - added support for agent workflows.
+        - all - general module cleanup.
+      release_summary: Adds agent workflow support and applies general module cleanup.
+    release_date: '2026-05-28'
+  2.0.9:
+    changes:
+      minor_changes:
+        - all - refactored every module to follow the updated development guidelines.
+        - all - updated the plugin development guidelines.
+      release_summary: Maintenance release that refreshes the plugin development guidelines and refactors all modules
+        to follow them. No functional changes.
+    release_date: '2026-06-03'
+  2.1.0:
+    changes:
+      breaking_changes:
+        - access_apps - the ``type`` option is restricted to ``self_hosted``, ``ssh``, and ``vnc``.
+        - access_policies - removed the ``precedence`` option; the account-level Access policy API does not accept
+          it.
+        - zones - removed the ``internal`` zone type.
+      bugfixes:
+        - all - numerous idempotency and convergence fixes, including complete pagination in lookups and info modules,
+          write-only secret comparison, preserved omitted fields on update, and stricter bulk-operation handling.
+      minor_changes:
+        - all - resource lookups use server-side filters and follow API pagination where supported.
+        - cfd_tunnel, pages_projects, warp_connector - added ``rotate_secrets`` to apply write-only secrets to existing
+          resources.
+        - galaxy.yml - constrained ``community.general`` to ``<11.0.0`` for ansible-core 2.15 compatibility.
+        - rules_lists - added ``operation_timeout`` to bound bulk item operations.
+      release_summary: Hardening release. Modules follow API pagination, converge more reliably, and handle Cloudflare
+        errors and long-running operations predictably. Review the breaking changes before upgrading.
+      security_fixes:
+        - access_apps, access_apps_info, access_identity_providers_info - secret fields in SCIM and identity provider
+          responses are redacted.
+        - examples, cfd_tunnel - removed a hardcoded tunnel secret; provide ``CLOUDFLARE_TUNNEL_SECRET`` via the
+          environment instead.
+        - pages_projects - ``deployment_configs`` is not logged; it can contain ``secret_text`` values.
+    release_date: '2026-07-14'
+  2.1.1:
+    changes:
+      bugfixes:
+        - access_apps - the ``type`` option is no longer restricted to a subset of application types; ``warp`` and
+          other valid Cloudflare Access application types are accepted again.
+      release_summary: Bugfix release that restores support for all Cloudflare Access application types.
+    release_date: '2026-07-14'
+  2.1.2:
+    changes:
+      breaking_changes:
+        - Raised the minimum supported ansible-core version to 2.18.0 and the community.general dependency to ``>=12.0.0,<14.0.0``.
+      bugfixes:
+        - access_groups - paginate the name lookup so groups beyond the first page of name-filter matches are found
+          instead of recreated.
+        - access_service_tokens - paginate the name lookup so tokens beyond the first page of name-filter matches
+          are found instead of recreated.
+        - pages_projects_info - paginate the Pages projects listing so accounts with more projects than one API
+          page return complete results.
+      release_summary: Maintenance release. Listing and name lookups follow API pagination everywhere, and the collection
+        now requires ansible-core 2.18 and community.general 12.
+    fragments:
+      - community_general_12.yml
+      - pagination_fixes.yml
+      - release_summary.yml
+    release_date: '2026-07-16'
 ...

--- a/changelogs/fragments/community_general_12.yml
+++ b/changelogs/fragments/community_general_12.yml
@@ -1,5 +1,0 @@
----
-breaking_changes:
-  - Raised the minimum supported ansible-core version to 2.18.0 and the
-    community.general dependency to ``>=12.0.0,<14.0.0``.
-...

--- a/changelogs/fragments/pagination_fixes.yml
+++ b/changelogs/fragments/pagination_fixes.yml
@@ -1,9 +1,0 @@
----
-bugfixes:
-  - pages_projects_info - paginate the Pages projects listing so accounts with
-    more projects than one API page return complete results.
-  - access_groups - paginate the name lookup so groups beyond the first page
-    of name-filter matches are found instead of recreated.
-  - access_service_tokens - paginate the name lookup so tokens beyond the
-    first page of name-filter matches are found instead of recreated.
-...

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -52,5 +52,5 @@ repository: https://github.com/linuxhq/ansible-collection-cloudflare
 tags:
   - cloudflare
   - infrastructure
-version: 2.1.1
+version: 2.1.2
 ...


### PR DESCRIPTION
## Summary
- Cut v2.1.2: changelog release consuming the pending fragments (pagination bugfixes; ansible-core 2.18 / community.general 12 requirement bump)
- Restyle the regenerated changelogs/changelog.yaml to the repo's strict yamllint format
- Ignore the generated changelogs/.plugin-cache.yaml

Tag v2.1.2 will be pushed after merge to trigger the Galaxy publish.