### PR TITLE
Paginate zones_info and remove page/per_page options

### DIFF
--- a/changelogs/fragments/zones_info_pagination.yml
+++ b/changelogs/fragments/zones_info_pagination.yml
@@ -1,0 +1,5 @@
+---
+breaking_changes:
+  - zones_info - removed the ``page`` and ``per_page`` options; the module now
+    follows API pagination and returns all zones.
+...

--- a/plugins/modules/zones_info.py
+++ b/plugins/modules/zones_info.py
@@ -28,16 +28,6 @@ options:
     default: all
     description:
       - Match.
-  page:
-    type: int
-    default: 1
-    description:
-      - Page.
-  per_page:
-    type: int
-    default: 20
-    description:
-      - Per page.
 requirements:
   - python >= 3.9
   - cloudflare >= 4.3.1, < 5
@@ -64,7 +54,7 @@ from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.linuxhq.cloudflare.plugins.module_utils.cloudflare_utils import (
     cloudflare_client,
-    get_result,
+    list_all,
 )
 
 
@@ -73,23 +63,12 @@ def main():
         argument_spec={
             "api_token": {"required": True, "type": "str", "no_log": True},
             "match": {"type": "str", "choices": ["any", "all"], "default": "all"},
-            "page": {"type": "int", "default": 1},
-            "per_page": {"type": "int", "default": 20},
         },
         supports_check_mode=True,
     )
 
     with cloudflare_client(module) as client:
-        zones = get_result(
-            client,
-            "/zones?match=%s&page=%s&per_page=%s"
-            % (
-                module.params["match"],
-                module.params["page"],
-                module.params["per_page"],
-            ),
-            default=[],
-        )
+        zones = list_all(client, "/zones?match=%s" % module.params["match"])
 
     module.exit_json(changed=False, zones=zones)
 

--- a/roles/zones_info/README.md
+++ b/roles/zones_info/README.md
@@ -12,8 +12,6 @@ Gather information about cloudflare zones
 
     zones_info_api_token: null
     zones_info_match: all
-    zones_info_page: 1
-    zones_info_per_page: 20
 
 ## Return Values
 

--- a/roles/zones_info/defaults/main.yml
+++ b/roles/zones_info/defaults/main.yml
@@ -1,6 +1,4 @@
 ---
 zones_info_api_token: null
 zones_info_match: all
-zones_info_page: 1
-zones_info_per_page: 20
 ...

--- a/roles/zones_info/tasks/main.yml
+++ b/roles/zones_info/tasks/main.yml
@@ -5,8 +5,6 @@
   linuxhq.cloudflare.zones_info:
     api_token: "{{ zones_info_api_token }}"
     match: "{{ zones_info_match }}"
-    page: "{{ zones_info_page }}"
-    per_page: "{{ zones_info_per_page }}"
   register: __zones_info_query
   when:
     - zones_info_api_token is not none


### PR DESCRIPTION
## Summary
- `zones_info` now follows API pagination via the shared `list_all` helper and returns all zones instead of a single manually-selected page
- Removed the `page` and `per_page` options from the module (`match` is kept); breaking change captured in a changelog fragment
- Updated the `zones_info` role in lockstep: dropped `zones_info_page`/`zones_info_per_page` from tasks, defaults, and README

## Verification
- black, ruff, yamllint, ansible-lint, and `ansible-test sanity` all pass
- Live probe confirmed `/zones` has no hard `per_page` cap and multi-page iteration returns every zone exactly once
- Full molecule cycle for `zones_info` passed, including the idempotence check