### PR TITLE
chore: add external link to license badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # linuxhq.cloudflare
 
-![License](https://img.shields.io/badge/license-GPLv3-lightgreen)
+[![License](https://img.shields.io/badge/license-GPLv3-lightgreen)](https://www.gnu.org/licenses/gpl-3.0.en.html#license-text)
 [![Ansible Galaxy](https://img.shields.io/badge/collection-linuxhq.cloudflare-blue)](https://galaxy.ansible.com/linuxhq/cloudflare)
 [![Lint](https://github.com/linuxhq/ansible-collection-cloudflare/actions/workflows/pre-commit.yml/badge.svg)](https://github.com/linuxhq/ansible-collection-cloudflare/actions/workflows/pre-commit.yml)
 [![Release](https://github.com/linuxhq/ansible-collection-cloudflare/actions/workflows/release.yml/badge.svg)](https://github.com/linuxhq/ansible-collection-cloudflare/actions/workflows/release.yml)


### PR DESCRIPTION
## Summary
- Make the license badge in README.md a clickable link to the GPLv3 license text

## Test plan
- Verify the badge renders as a clickable link pointing to https://www.gnu.org/licenses/gpl-3.0.en.html#license-text