### PR TITLE
chore: add ansible-test to tox env_list and lint label

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 env_list =
     ansible-lint
+    ansible-test
     black-lint
     isort-lint
     ruff-lint
@@ -11,6 +12,7 @@ skip_missing_interpreters = true
 
 [common]
 ansible_home = {envtmpdir}/ansible_home
+python_version = 3.13
 ansible_collections_path = {[common]ansible_home}/collections
 full_collection_path = {[common]ansible_collections_path}/ansible_collections/linuxhq/cloudflare
 format_dirs = {toxinidir}/plugins {toxinidir}/tests
@@ -37,6 +39,7 @@ deps =
 commands = ansible-lint {posargs}
 
 [testenv:ansible-test]
+labels = lint
 description = Run ansible-test from the required collection layout
 deps =
     -r requirements.txt
@@ -54,7 +57,7 @@ commands_pre =
     ansible-galaxy collection install -r {toxinidir}/requirements.yml -p {[common]ansible_collections_path}
     git init --quiet
     git add --all
-commands = ansible-test {posargs:sanity} --requirements --venv-system-site-packages
+commands = ansible-test {posargs:sanity} --python {[common]python_version} --requirements --venv-system-site-packages
 
 [testenv:black]
 labels = format


### PR DESCRIPTION
## Summary
- Add `ansible-test` to the default `env_list` so `tox` runs it alongside other checks
- Add `labels = lint` so `tox run -m lint` includes it
- Pin `--python 3.13` via `[common]python_version` to avoid scanning for uninstalled interpreters