### PR TITLE
chore: derive base_python from common python_version in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ known_ansible_core = ansible
 known_ansible_linuxhq_cloudflare = ansible_collections.linuxhq.cloudflare
 
 [testenv]
-base_python = python3.13
+base_python = python{[common]python_version}
 change_dir = {toxinidir}
 
 [testenv:ansible-lint]


### PR DESCRIPTION
## Summary
- Replace the hardcoded `base_python = python3.13` with `python{[common]python_version}` so `[common] python_version` is the single source of truth for the interpreter, matching the `{[common]...}` substitution pattern used throughout the file.

Previously a Python bump required editing two lines; missing one would silently let the tox env interpreter diverge from the ansible-test `--python` target.