### PR TITLE
Configure blank-line-after-blocks and format Python blocks

### DIFF
--- a/.agents/skills/blank-line-after-blocks/SKILL.md
+++ b/.agents/skills/blank-line-after-blocks/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: blank-line-after-blocks
+description: Add blank lines after Python control-flow blocks through Tox.
+---
+
+# blank-line-after-blocks
+
+Uses the version pinned in `requirements.txt`, matching the pre-commit hook.
+Tox and the pre-commit hook both cover Python files under `plugins/` and `tests/`.
+
+```sh
+tox run -e blank-line-after-blocks
+tox run -e blank-line-after-blocks -- plugins/modules/{{ file }}.py
+```
+
+- Exit code 1 with `Rewriting` messages means files were formatted. Inspect
+  the diff and rerun; a clean second run exits 0. Investigate tracebacks or
+  other errors instead of treating every exit code 1 as success.
+- Run the upstream formatter directly; it modifies files.
+- Use the Black skill afterward, retaining the configured 120-character
+  limit. Check that another spacing pass makes no changes.
+- It separates completed `if`, `for`, `while`, `with`, and `try` blocks.
+  It does not infer semantic boundaries between consecutive simple statements.
+- CI enforces spacing through pre-commit. This environment belongs to the
+  `format` label, not `lint`, because it modifies files.
+
+## Dependencies
+
+- `tox` skill
+- `black` skill

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,13 @@ repos:
         files: \.(yaml|yml)$
         verbose: true
 
+  - repo: https://github.com/jsh9/blank-line-after-blocks
+    rev: 0.1.4
+    hooks:
+      - id: blank-line-after-blocks
+        files: ^(plugins|tests)/.*\.py$
+        verbose: true
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.16.5
     hooks:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,21 +27,22 @@ Always-on agent rules.  Append new rules to imports section below.
 
 Invoke skills rather than running commands ad hoc.
 
-| Skill              | Purpose                       |
-| ------------------ | ----------------------------- |
-| `ansible-lint`     | Lint roles & playbooks        |
-| `black`            | Format Python                 |
-| `ansible-test`     | Module sanity                 |
-| `changelog`        | Changelog fragments & release |
-| `collection-build` | Build the collection tarball  |
-| `isort`            | Sort Python imports           |
-| `molecule`         | Role tests                    |
-| `plugins-audit`    | Exhaustive plugins audit      |
-| `pyenv`            | Install pyenv + pinned Python |
-| `ruff`             | Lint Python                   |
-| `tox`              | Set up isolated environments  |
-| `unit`             | Run Python unit tests         |
-| `yamllint`         | Lint YAML                     |
+| Skill                     | Purpose                       |
+| ------------------------- | ----------------------------- |
+| `ansible-lint`            | Lint roles & playbooks        |
+| `black`                   | Format Python                 |
+| `blank-line-after-blocks` | Space Python blocks           |
+| `ansible-test`            | Module sanity                 |
+| `changelog`               | Changelog fragments & release |
+| `collection-build`        | Build the collection tarball  |
+| `isort`                   | Sort Python imports           |
+| `molecule`                | Role tests                    |
+| `plugins-audit`           | Exhaustive plugins audit      |
+| `pyenv`                   | Install pyenv + pinned Python |
+| `ruff`                    | Lint Python                   |
+| `tox`                     | Set up isolated environments  |
+| `unit`                    | Run Python unit tests         |
+| `yamllint`                | Lint YAML                     |
 
 ## Setup
 

--- a/plugins/module_utils/cloudflare_utils.py
+++ b/plugins/module_utils/cloudflare_utils.py
@@ -51,10 +51,12 @@ def api_request(client, method, path, body=None, ok_statuses=None, timeout=None)
     try:
         if method in ("post", "put", "patch", "delete"):
             return request(path, cast_to=object, body=body, options=options)
+
         return request(path, cast_to=object, options=options)
     except cloudflare.APIStatusError as exc:
         if getattr(exc, "status_code", None) in ok_statuses:
             return None
+
         exc._cloudflare_message = f"Cloudflare API {method.upper()} request failed"
         exc._cloudflare_context = {"method": method.upper(), "path": path}
         raise
@@ -106,6 +108,7 @@ def validate_cloudflare_params(module):
     api_token = module.params.get("api_token")
     if not isinstance(api_token, str) or not api_token.strip():
         module.fail_json(msg="api_token must not be empty")
+
     if any(ord(character) < 32 or ord(character) == 127 for character in api_token):
         module.fail_json(msg="api_token must not contain control characters")
 
@@ -115,8 +118,10 @@ def validate_cloudflare_params(module):
         ):
             if not value.strip():
                 module.fail_json(msg=f"{name} must not be empty")
+
             if value != value.strip():
                 module.fail_json(msg=f"{name} must not contain leading or trailing whitespace")
+
     return api_token.strip()
 
 
@@ -124,6 +129,7 @@ def delete_result(client, path, expected_id=None):
     result = response_result(api_request(client, "delete", path))
     if expected_id is not None and (not isinstance(result, dict) or result.get("id") != expected_id):
         raise CloudflareResponseError("Cloudflare API returned the wrong deleted resource")
+
     return result
 
 
@@ -141,8 +147,10 @@ def fail_from_cloudflare_error(module, message, exc, **context):
     failure = {"msg": message, **redact_sensitive_values(context)}
     if response is None:
         failure["error"] = str(exc)
+
     if status_code is not None:
         failure["status_code"] = status_code
+
     if response_body is not None:
         failure["response"] = redact_sensitive_values(response_body)
 
@@ -157,6 +165,7 @@ def cloudflare_query(path, values):
     query = urlencode([(key, value) for key, value in values.items() if value is not None])
     if not query:
         return path
+
     return f"{path}{'&' if '?' in path else '?'}{query}"
 
 
@@ -164,6 +173,7 @@ def find_by_field(client, path, field, value, paginate=True):
     for item in iter_items(client, path, paginate=paginate):
         if not isinstance(item, dict):
             raise CloudflareResponseError("Cloudflare API returned malformed resource data")
+
         item_value = item.get(field)
         if (
             item_value is None
@@ -171,6 +181,7 @@ def find_by_field(client, path, field, value, paginate=True):
             and (not isinstance(item_value, str) or not item_value.strip() or item_value != item_value.strip())
         ):
             raise CloudflareResponseError("Cloudflare API returned malformed resource data")
+
         if item_value == value:
             return item
 
@@ -242,9 +253,12 @@ def iter_items(client, path, per_page=50, paginate=True):
         if total_pages is not None and page >= total_pages:
             if total_count is not None and fetched < total_count:
                 raise CloudflareResponseError("Cloudflare API returned malformed pagination data")
+
             return
+
         if total_pages is None and total_count is not None and fetched >= total_count:
             return
+
         if total_pages is None and total_count is None and len(result) < per_page:
             return
 
@@ -259,11 +273,13 @@ def normalize_current_by_desired_fields(current, desired):
     if isinstance(current, dict) and isinstance(desired, dict):
         if not desired:
             return current
+
         return {key: normalize_current_by_desired_fields(current.get(key), value) for key, value in desired.items()}
 
     if isinstance(current, list) and isinstance(desired, list):
         if len(current) != len(desired):
             return current
+
         return [
             normalize_current_by_desired_fields(current_item, desired_item)
             for current_item, desired_item in zip(current, desired)
@@ -276,14 +292,18 @@ def parse_list_response(response):
     if isinstance(response, dict) and ("result" in response or "success" in response):
         if "success" in response and not isinstance(response["success"], bool):
             raise CloudflareResponseError("Cloudflare API returned malformed list data")
+
         if response.get("success") is False:
             raise CloudflareResponseError("Cloudflare API returned an unsuccessful response")
+
         if "result" not in response:
             raise CloudflareResponseError("Cloudflare API returned malformed list data")
+
         result = response.get("result")
         result_info = response.get("result_info")
         if result is None:
             result = []
+
         if result_info is None:
             result_info = {}
     else:
@@ -323,6 +343,7 @@ def remove_fields(value, fields):
     if isinstance(value, dict):
         for field in fields:
             value.pop(field, None)
+
         for item in value.values():
             remove_fields(item, fields)
     elif isinstance(value, list):
@@ -345,6 +366,7 @@ def redact_pages_secrets(resource):
             value.pop("web_analytics_token", None)
             if value.get("type") == "secret_text":
                 value.pop("value", None)
+
             for item in value.values():
                 redact(item)
         elif isinstance(value, list):
@@ -379,8 +401,10 @@ def resource_field(module, resource, field, resource_name, expected=None):
         module.fail_json(
             msg=f"Cloudflare API returned malformed {resource_name} data",
         )
+
     if expected is not None and value != expected:
         module.fail_json(msg=f"Cloudflare API returned the wrong {resource_name}")
+
     return value
 
 
@@ -412,11 +436,13 @@ def validate_requested_values(module, resource, desired, resource_name):
 def validate_tunnel_secret(module, secret):
     if secret is None:
         return
+
     try:
         if len(b64decode(secret, validate=True)) >= 32:
             return
     except ValueError:
         pass
+
     module.fail_json(msg="tunnel_secret must be base64-encoded and at least 32 bytes")
 
 
@@ -429,13 +455,17 @@ def response_result(response, default=None):
     if isinstance(response, dict) and ("result" in response or "success" in response):
         if "success" in response and not isinstance(response["success"], bool):
             raise CloudflareResponseError("Cloudflare API returned malformed data")
+
         if response.get("success") is False:
             raise CloudflareResponseError("Cloudflare API returned an unsuccessful response")
+
         if "result" not in response:
             raise CloudflareResponseError("Cloudflare API returned malformed data")
+
         result = response.get("result")
         if result is None:
             return default
+
         return result
 
     if response is None:

--- a/plugins/modules/access_identity_providers_info.py
+++ b/plugins/modules/access_identity_providers_info.py
@@ -95,6 +95,7 @@ def list_resources(module, client):
         name = provider.get("name")
         if not isinstance(name, str) or name != name.strip():
             module.fail_json(msg="Cloudflare API returned malformed Access identity provider data")
+
         for section, field in (("config", "client_secret"), ("scim_config", "secret")):
             remove_fields(provider.get(section), (field,))
 

--- a/plugins/modules/access_service_tokens.py
+++ b/plugins/modules/access_service_tokens.py
@@ -135,9 +135,11 @@ def service_token_payload(module):
 def duration_matches(service_token, duration):
     if duration is None:
         return True
+
     current_duration = service_token.get("duration")
     if current_duration is not None:
         return current_duration == duration
+
     return duration == "forever" and service_token.get("expires_at") in (None, "")
 
 
@@ -162,10 +164,12 @@ def ensure_present(module, client):
             service_token = serialize_resource(
                 client.zero_trust.access.service_tokens.create(**service_token_payload(module))
             )
+
         resource_id(module, service_token, "service token")
         resource_field(module, service_token, "name", "service token", expected=params["name"])
         if not duration_matches(service_token, params["duration"]):
             module.fail_json(msg="Cloudflare did not apply the requested service token duration")
+
         module.exit_json(
             changed=True,
             message="Service token created",
@@ -196,11 +200,13 @@ def ensure_present(module, client):
             current_id,
             **service_token_payload(module),
         )
+
     service_token = serialize_resource(service_token)
     resource_id(module, service_token, "service token", expected=current_id)
     resource_field(module, service_token, "name", "service token", expected=params["name"])
     if not duration_matches(service_token, params["duration"]):
         module.fail_json(msg="Cloudflare did not apply the requested service token duration")
+
     module.exit_json(
         changed=True,
         message="Service token updated",
@@ -240,6 +246,7 @@ def ensure_absent(module, client):
                 account_id=params["account_id"],
             )
         )
+
     resource_id(module, deleted_token, "service token", expected=current_id)
     module.exit_json(
         changed=True,

--- a/plugins/modules/cfd_tunnel.py
+++ b/plugins/modules/cfd_tunnel.py
@@ -151,6 +151,7 @@ def ensure_present(module, client):
             remote = current.get("config_src") == "cloudflare" or current.get("remote_config") is True
             if not local or remote:
                 module.fail_json(msg="tunnel_secret is only valid for locally-managed tunnels")
+
             if module.check_mode:
                 module.exit_json(
                     changed=True,
@@ -185,6 +186,7 @@ def ensure_present(module, client):
 
     if not params.get("config_src"):
         module.fail_json(msg="config_src is required when creating a cloudflared tunnel")
+
     if params["config_src"] != "local" and params.get("tunnel_secret") is not None:
         module.fail_json(msg="tunnel_secret is only valid for locally-managed tunnels")
 

--- a/plugins/modules/cfd_tunnel_configurations.py
+++ b/plugins/modules/cfd_tunnel_configurations.py
@@ -138,6 +138,7 @@ def ensure_present(module, client):
         params["config"],
     ):
         module.fail_json(msg="Cloudflare did not apply the tunnel configuration")
+
     module.exit_json(
         changed=True,
         message="Tunnel configuration updated",

--- a/plugins/modules/dnssec.py
+++ b/plugins/modules/dnssec.py
@@ -161,6 +161,7 @@ def ensure_present(module, client):
         zone_id=module.params["zone_id"],
     ):
         current = serialize_resource(client.dns.dnssec.get(zone_id=module.params["zone_id"]))
+
     require_mapping(module, current, "DNSSEC settings")
     current_status = normalized_status(resource_field(module, current, "status", "DNSSEC settings"))
 
@@ -211,6 +212,7 @@ def ensure_present(module, client):
         zone_id=module.params["zone_id"],
     ):
         dnssec = serialize_resource(client.dns.dnssec.edit(**payload))
+
     require_mapping(module, dnssec, "DNSSEC settings")
     response_status = normalized_status(resource_field(module, dnssec, "status", "DNSSEC settings"))
     if any(
@@ -223,6 +225,7 @@ def ensure_present(module, client):
         )
     ):
         module.fail_json(msg="Cloudflare did not apply the requested DNSSEC settings")
+
     module.exit_json(
         changed=True,
         message="DNSSEC settings updated",

--- a/plugins/modules/pagerules.py
+++ b/plugins/modules/pagerules.py
@@ -158,8 +158,10 @@ def pagerule_targets(module, pagerule):
     targets = pagerule.get("targets")
     if not isinstance(targets, list):
         module.fail_json(msg="Cloudflare API returned malformed page rule data")
+
     for target in targets:
         require_mapping(module, target, "page rule target")
+
     return targets
 
 
@@ -172,7 +174,9 @@ def find_pagerule(module, client):
         ):
             if found is not None:
                 module.fail_json(msg="Multiple page rules match the requested target constraints")
+
             found = pagerule
+
     return found
 
 

--- a/plugins/modules/pagerules_info.py
+++ b/plugins/modules/pagerules_info.py
@@ -107,6 +107,7 @@ def list_resources(module, client):
                 values = rule.get(field)
                 if not isinstance(values, list):
                     module.fail_json(msg="Cloudflare API returned malformed page rule data")
+
                 for value in values:
                     require_mapping(module, value, f"page rule {field[:-1]}")
 

--- a/plugins/modules/pages_projects.py
+++ b/plugins/modules/pages_projects.py
@@ -172,6 +172,7 @@ def comparable_pages_payload(payload):
     build_config = payload.get("build_config")
     if isinstance(build_config, dict) and set(build_config) == {"web_analytics_token"}:
         comparable.pop("build_config")
+
     return comparable
 
 
@@ -210,10 +211,12 @@ def current_domain_names(module, project, domains):
     for name in project_domains:
         if not isinstance(name, str) or not name.strip() or name != name.strip():
             module.fail_json(msg="Cloudflare API returned malformed Pages domain data")
+
         names.add(name)
 
     for domain in domains:
         names.add(resource_field(module, domain, "name", "Pages domain"))
+
     return names
 
 
@@ -223,8 +226,10 @@ def desired_domain_names(module):
         domain_name = domain.get("name") if isinstance(domain, dict) else None
         if not isinstance(domain_name, str) or not domain_name.strip() or domain_name != domain_name.strip():
             module.fail_json(msg="Each Pages project domain requires a valid name")
+
         if domain_name not in names:
             names.append(domain_name)
+
     return names
 
 

--- a/plugins/modules/rules_lists.py
+++ b/plugins/modules/rules_lists.py
@@ -214,8 +214,10 @@ def list_items(module, client, account_id, list_id):
                 per_page=ITEMS_PER_PAGE,
             )
         ]
+
     for item in items:
         require_mapping(module, item, "Rules list item")
+
     return items
 
 
@@ -233,6 +235,7 @@ def operation_endpoint(account_id, operation_id):
 def pending_operation_error(exc):
     if getattr(exc, "status_code", None) not in (400, 409, 429):
         return False
+
     return "operation" in str(exc).lower()
 
 
@@ -271,6 +274,7 @@ def wait_for_operation(module, client, account_id, operation, deadline):
     operation_id = None
     if isinstance(operation, dict):
         operation_id = operation.get("operation_id") or operation.get("id")
+
     if not isinstance(operation_id, str) or not operation_id.strip() or operation_id != operation_id.strip():
         module.fail_json(
             msg="Rules list items submission did not return an operation id",
@@ -303,6 +307,7 @@ def wait_for_operation(module, client, account_id, operation, deadline):
                     operation_id=operation_id,
                     operation=status,
                 )
+
             status = {}
             time.sleep(min(OPERATION_POLL_SECONDS, max(deadline - time.monotonic(), 0)))
             continue
@@ -525,6 +530,7 @@ def ensure_present(module, client):
     }
     if items_operation is not None:
         result["items_operation"] = items_operation
+
     module.exit_json(**result)
 
 

--- a/plugins/modules/rulesets.py
+++ b/plugins/modules/rulesets.py
@@ -144,10 +144,13 @@ def rules_from_resource(module, ruleset):
     rules = ruleset.get("rules")
     if rules is None:
         return []
+
     if not isinstance(rules, list):
         module.fail_json(msg="Cloudflare API returned malformed ruleset data")
+
     for rule in rules:
         require_mapping(module, rule, "ruleset rule")
+
     return rules
 
 

--- a/plugins/modules/rulesets_info.py
+++ b/plugins/modules/rulesets_info.py
@@ -117,12 +117,14 @@ def list_resources(module, client):
                 rules = []
             elif not isinstance(rules, list):
                 module.fail_json(msg="Cloudflare API returned malformed ruleset data")
+
             for rule in rules:
                 require_mapping(module, rule, "ruleset rule")
 
         entry = {"name": zone_name, "rules": rules, "zone_id": zone_id}
         if ruleset is not None:
             entry.update(id=ruleset_id, phase=ruleset["phase"])
+
         rulesets.append(entry)
 
     module.exit_json(changed=False, rulesets=rulesets)

--- a/plugins/modules/warp_connector.py
+++ b/plugins/modules/warp_connector.py
@@ -207,6 +207,7 @@ def ensure_present(module, client):
                     ),
                     warp_connector_id=connector_id,
                 )
+
             raise
 
     module.exit_json(

--- a/plugins/modules/zones.py
+++ b/plugins/modules/zones.py
@@ -174,6 +174,7 @@ def normalize_setting_value(value):
 def zone_endpoint(zone_id=None):
     if zone_id is None:
         return cloudflare_path("zones")
+
     return cloudflare_path("zones", zone_id)
 
 
@@ -190,6 +191,7 @@ def ensure_present(module, client):
             or setting["id"] in setting_ids
         ):
             module.fail_json(msg="Each zone setting requires a unique valid id and value")
+
         setting_ids.add(setting["id"])
 
     current = find_by_name(
@@ -250,6 +252,7 @@ def ensure_present(module, client):
             resource_field(module, current, "name", "zone", expected=params["name"])
             validate_requested_values(module, current, payload, "zone")
             changed = True
+
         created = False
 
     updated_settings = []
@@ -280,8 +283,10 @@ def ensure_present(module, client):
         resource_id(module, updated_setting, "zone setting", expected=setting["id"])
         if "value" not in updated_setting:
             module.fail_json(msg="Cloudflare API returned malformed zone setting data")
+
         if normalize_setting_value(updated_setting["value"]) != normalize_setting_value(setting["value"]):
             module.fail_json(msg="Cloudflare did not apply the requested zone setting")
+
         updated_settings.append(updated_setting)
 
     if not changed and not updated_settings:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ ansible>=14.3.1,<15
 ansible-lint==26.8.0
 antsibull-changelog==0.35.1
 black==26.5.1
+blank-line-after-blocks==0.1.4
 cloudflare>=5.6.0,<6
 isort==9.0.1
 jmespath==1.1.0

--- a/tests/unit/plugins/module_utils/test_cloudflare_utils.py
+++ b/tests/unit/plugins/module_utils/test_cloudflare_utils.py
@@ -76,6 +76,7 @@ class SdkModel:
     def to_dict(self, mode=None):
         if mode != "json":
             raise ValueError("expected JSON serialization")
+
         return {
             "id": self.resource_id,
             "expires_at": self.expires_at.isoformat().replace("+00:00", "Z"),

--- a/tests/unit/plugins/modules/test_pages_projects_info.py
+++ b/tests/unit/plugins/modules/test_pages_projects_info.py
@@ -85,6 +85,7 @@ class PagesProjectsInfoTests(TestCase):
                 "web_analytics_token",
                 raised.exception.values["pages_projects"][0][field]["build_config"],
             )
+
         self.assertEqual(
             projects[0]["deployment_configs"]["production"]["env_vars"]["TOKEN"]["value"],
             "secret",

--- a/tox.ini
+++ b/tox.ini
@@ -59,6 +59,14 @@ commands_pre =
     git add --all
 commands = ansible-test {posargs:sanity} --python {[common]python_version} --requirements --venv-system-site-packages
 
+[testenv:blank-line-after-blocks]
+labels = format
+description = Add blank lines after Python blocks
+deps =
+    -c requirements.txt
+    blank-line-after-blocks
+commands = blank-line-after-blocks {posargs:{[common]format_dirs}}
+
 [testenv:black]
 labels = format
 description = Format Python files


### PR DESCRIPTION
Add the AWS collection's blank-line-after-blocks 0.1.4 dependency, pre-commit hook, Tox formatter environment, and agent skill. Apply the formatter to Python files under plugins/ and tests/, and align the AGENTS.md tooling table. Python changes only add blank lines after control-flow blocks.

Validation: `tox run -m format` passed with a clean second pass; `tox run -m lint` passed, including Ansible sanity checks. All commit hooks passed with the shell's missing vault-password-file setting unset for the commit command. `git diff --check` passed.
