### PR TITLE
chore: align CI, release gates, and local tooling

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,5 +1,6 @@
 ---
 exclude_paths:
+  - .tox
   - molecule
   - venv
 offline: false

--- a/.claude/rules
+++ b/.claude/rules
@@ -1,1 +1,0 @@
-../.agents/rules

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,1 +1,0 @@
-../.agents/skills

--- a/.codex/rules
+++ b/.codex/rules
@@ -1,1 +1,0 @@
-../.agents/rules

--- a/.codex/skills
+++ b/.codex/skills
@@ -1,1 +1,0 @@
-../.agents/skills

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -1,8 +1,9 @@
 ---
 'on':
   push:
-    branches: main
+    branches: '**'
   pull_request:
+  workflow_call:
 
 permissions:
   contents: read
@@ -35,10 +36,8 @@ jobs:
           sparse-checkout: |
             /*
             !/.agents/
-            !/.claude/
-            !/.codex/
           sparse-checkout-cone-mode: false
-      - run: git rm --cached --quiet -r --sparse .agents .claude .codex
+      - run: git rm --cached --quiet -r --sparse .agents
       - uses: actions/setup-python@v7
         with:
           python-version: "${{ matrix.python }}"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,8 +1,12 @@
 ---
 'on':
   push:
-    branches: '*'
+    branches: '**'
   pull_request:
+  workflow_call:
+
+permissions:
+  contents: read
 
 jobs:
   pre-commit:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,17 +2,36 @@
 'on':
   push:
     tags:
-      - '*'
+      - 'v*'
+
+permissions:
+  contents: read
 
 jobs:
+  pre-commit:
+    uses: ./.github/workflows/pre-commit.yml
+
+  sanity:
+    uses: ./.github/workflows/ansible-test.yml
+
   release:
+    needs:
+      - pre-commit
+      - sanity
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
         with:
-          python-version-file: .python-version
-      - run: pip install --constraint requirements.txt ansible
+          python-version: '3.12'
+      - run: pip install ansible-core==2.18.0
+      - name: Verify tag matches galaxy.yml version
+        run: |
+          tag_version="${GITHUB_REF_NAME#v}"
+          galaxy_version="$(awk '/^version:/ {print $2}' galaxy.yml)"
+          if [ "${tag_version}" != "${galaxy_version}" ]; then
+            echo "Tag v${tag_version} does not match galaxy.yml version ${galaxy_version}" >&2
+            exit 1
+          fi
       - run: ansible-galaxy collection build
       - run: ansible-galaxy collection publish --api-key ${{ secrets.GALAXY_API_KEY }} linuxhq-cloudflare-*.tar.gz
-...

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,26 +34,24 @@ repos:
         files: ^(plugins|tests)/.*\.py$
         verbose: true
 
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.16.5
-    hooks:
-      - id: ruff-check
-        exclude: ^venv/
-        files: \.(py)$
-        verbose: true
-
   - repo: https://github.com/PyCQA/isort
     rev: 9.0.1
     hooks:
       - id: isort
-        files: \.(py)$
+        files: ^(plugins|tests)/.*\.py$
         verbose: true
 
   - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 26.5.1
     hooks:
       - id: black
-        exclude: ^venv/
-        files: \.(py)$
+        files: ^(plugins|tests)/.*\.py$
+        verbose: true
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.16.6
+    hooks:
+      - id: ruff-check
+        files: ^(plugins|tests)/.*\.py$
         verbose: true
 ...

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,0 @@
-AGENTS.md

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -7,10 +7,6 @@ build_ignore:
   - .ansible
   - .ansible/**
   - .ansible-lint
-  - .claude
-  - .claude/**
-  - .codex
-  - .codex/**
   - .config
   - .config/**
   - .DS_Store
@@ -29,7 +25,6 @@ build_ignore:
   - AGENTS.md
   - ansible.cfg
   - changelogs/.plugin-cache.yaml
-  - CLAUDE.md
   - requirements.txt
   - requirements.yml
   - pyproject.toml

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,5 @@ netaddr==1.3.0
 pre-commit==4.6.2
 pytest==9.1.1
 python-vagrant==1.0.0
-ruff==0.16.5
+ruff==0.16.6
 yamllint==1.38.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,5 @@
 [tox]
+requires = tox>=4.51
 env_list =
     ansible-lint
     ansible-test
@@ -12,7 +13,6 @@ skip_missing_interpreters = true
 
 [common]
 ansible_home = {envtmpdir}/ansible_home
-python_version = 3.13
 ansible_collections_path = {[common]ansible_home}/collections
 full_collection_path = {[common]ansible_collections_path}/ansible_collections/linuxhq/cloudflare
 format_dirs = {toxinidir}/plugins {toxinidir}/tests
@@ -21,14 +21,14 @@ lint_dirs = {toxinidir}/plugins {toxinidir}/tests
 [isort]
 line_length = 120
 profile = black
-skip = .tox, tests/output
-src_paths = plugins, tests/unit
-sections = FUTURE,STDLIB,THIRDPARTY,ANSIBLE_CORE,ANSIBLE_LINUXHQ_CLOUDFLARE,LOCALFOLDER
+skip = .tox, venv, tests/output
+src_paths = plugins, tests
+sections = FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,ANSIBLE_CORE,ANSIBLE_LINUXHQ_CLOUDFLARE,LOCALFOLDER
 known_ansible_core = ansible
 known_ansible_linuxhq_cloudflare = ansible_collections.linuxhq.cloudflare
 
 [testenv]
-base_python = python{[common]python_version}
+base_python_file = {toxinidir}/.python-version
 change_dir = {toxinidir}
 
 [testenv:ansible-lint]
@@ -53,11 +53,11 @@ set_env =
     ANSIBLE_COLLECTIONS_PATH={[common]ansible_collections_path}
     ANSIBLE_COLLECTIONS_SCAN_SYS_PATH=false
 commands_pre =
-    rsync --delete --filter=':- .gitignore' --exclude=/.agents --exclude=/.claude --exclude=/.codex --exclude=/.git -qraugpo {toxinidir}/ {[common]full_collection_path}/
+    rsync --delete --filter=':- .gitignore' --exclude=/.agents --exclude=/.git -qraugpo {toxinidir}/ {[common]full_collection_path}/
     ansible-galaxy collection install -r {toxinidir}/requirements.yml -p {[common]ansible_collections_path}
     git init --quiet
     git add --all
-commands = ansible-test {posargs:sanity} --python {[common]python_version} --requirements --venv-system-site-packages
+commands = ansible-test {posargs:sanity} --python {py_dot_ver} --requirements --venv-system-site-packages
 
 [testenv:blank-line-after-blocks]
 labels = format


### PR DESCRIPTION
CI now runs on nested branch names, and version-tag releases must pass the reusable pre-commit and Ansible sanity/unit workflows before publishing. Releases also verify that the tag matches `galaxy.yml` and build with a pinned Ansible Core version.

Align Tox with `.python-version`, update Ruff to 0.16.6, scope Python hooks to plugins and tests, exclude Tox environments from Ansible lint, and remove obsolete agent symlinks and their packaging exclusions.

Validation: full Tox lint group (including Ansible sanity), all 153 unit tests, commit hooks, and collection build passed. Inspected artifact version, dependencies, and file list. Local commit hooks ran with the inherited vault-password environment variable unset.
